### PR TITLE
Added streamlit path to domain

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,16 @@
+[server]
+enableCORS = true
+enableXsrfProtection = false
+runOnSave = true
+maxUploadSize = 200
+
+[browser]
+serverAddress = "tools.antematter.io"
+gatherUsageStats = false
+
+[theme]
+primaryColor = "#F63366"
+backgroundColor = "#FFFFFF"
+secondaryBackgroundColor = "#F0F2F6"
+textColor = "#262730"
+font = "sans serif" 


### PR DESCRIPTION
# [Streamlit path for domain]

## Description

The file will successfully tell Streamlit to be hosted on tools.antematter.io. So using Nginx we can only be handling proxy settings.